### PR TITLE
Improves ipython forward compatibility (v4.x)

### DIFF
--- a/liquid_tags/notebook.py
+++ b/liquid_tags/notebook.py
@@ -53,27 +53,51 @@ from .mdx_liquid_tags import LiquidTags
 import IPython
 IPYTHON_VERSION = IPython.version_info[0]
 
+try:
+    import nbformat
+except:
+    pass
+
 if not IPYTHON_VERSION >= 1:
     raise ValueError("IPython version 1.0+ required for notebook tag")
 
 try:
-    from IPython.nbconvert.filters.highlight import _pygments_highlight
+    from nbconvert.filters.highlight import _pygments_highlight
 except ImportError:
-    # IPython < 2.0
-    from IPython.nbconvert.filters.highlight import _pygment_highlight as _pygments_highlight
+    try:
+        from IPython.nbconvert.filters.highlight import _pygments_highlight
+    except ImportError:
+        # IPython < 2.0
+        from IPython.nbconvert.filters.highlight import _pygment_highlight as _pygments_highlight
 
 from pygments.formatters import HtmlFormatter
 
-from IPython.nbconvert.exporters import HTMLExporter
-from IPython.config import Config
+try:
+    from nbconvert.exporters import HTMLExporter
+except ImportError:
+        print("I was here 3")
+        from IPython.nbconvert.exporters import HTMLExporter
 
 try:
-    from IPython.nbconvert.preprocessors import Preprocessor
+    from traitlets.config import Config
 except ImportError:
-    # IPython < 2.0
-    from IPython.nbconvert.transformers import Transformer as Preprocessor
+    from IPython.config import Config
 
-from IPython.utils.traitlets import Integer
+try:
+    from nbconvert.preprocessors import Preprocessor
+except ImportError:
+    try:
+        print("I was here 4")
+        from IPython.nbconvert.preprocessors import Preprocessor
+    except ImportError:
+        # IPython < 2.0
+        from IPython.nbconvert.transformers import Transformer as Preprocessor
+
+try:
+    from traitlets import Integer
+except ImportError:
+    from IPython.utils.traitlets import Integer
+
 from copy import deepcopy
 
 #----------------------------------------------------------------------
@@ -209,7 +233,7 @@ class SubCell(Preprocessor):
                 worksheet.cells = cells[self.start:self.end]
         else:
             nbc.cells = nbc.cells[self.start:self.end]
-        
+
         return nbc, resources
 
     call = preprocess # IPython < 2.0
@@ -298,7 +322,10 @@ def notebook(preprocessor, tag, markup):
         if IPYTHON_VERSION < 3:
             nb_json = IPython.nbformat.current.reads_json(nb_text)
         else:
-            nb_json = IPython.nbformat.reads(nb_text, as_version=4)
+            try:
+                nb_json = nbformat.reads(nb_text, as_version=4)
+            except:
+                nb_json = IPython.nbformat.reads(nb_text, as_version=4)
 
     (body, resources) = exporter.from_notebook_node(nb_json)
 


### PR DESCRIPTION
This is an attempt to improve compatibility with v4.0 of the IPython / Jupyter packages.

* I did this by adding a layer of try:/import/except on top of the existing ones. It's brute force but it works though using the correct import after doing a version check might be preferable. Only one change was breaking the module as the nbformat module was called directly instead of being imported so there was no chance the shim provided by IPython 4.0 to ensure backward compatibility. The other changes fix the shim warnings.
* added another change in the REAME.md, a bit unrelated, to avoid the error on the first time the site is built due to the lack of _nb_header.html file. Still have to use the proper read() line depending on Python 2.x or 3.x usage.
* I can't manage to run tox on top of conda environments. I tested it for Python 3.4, IPython 3.2.1 and 4.0.